### PR TITLE
fix: remove nav border after firefox 122.0 upgrade

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -143,4 +143,5 @@ See the above repository for updates as well as full license text. */
 }
 #navigator-toolbox {
 	appearance: toolbar !important; /* Pretty much anything except none */
+	border: none !important;
 }


### PR DESCRIPTION
OS: Ubuntu 22.04.3 LTS
Version 122.0 64-bit (Standard)

The most recent Firefox upgrade added this thin border to the top of the window:

![before](https://github.com/rockofox/firefox-minima/assets/157634669/e798dafc-a887-422a-84b4-4862406c5441)

This change removes it:

![after](https://github.com/rockofox/firefox-minima/assets/157634669/63ab5fcb-7c52-4c67-8fe4-457a2c2f148a)

---

Great project! Thanks for hosting it.